### PR TITLE
typo on exception message

### DIFF
--- a/strava/exceptions.py
+++ b/strava/exceptions.py
@@ -3,7 +3,7 @@ class ImproperlyConfigured(Exception):
 
 
 class StravaError(Exception):
-    default_message = 'Unkown Error.'
+    default_message = 'Unknown Error.'
 
     def __init__(self, message=None, response=None, *args, **kwargs):
         self.message = message or self.default_message


### PR DESCRIPTION
Related to issue #13
Typo on exception default message  